### PR TITLE
Support .jsx

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -31,6 +31,7 @@ exports.compile = async (outputPath, benchmarkPath, debug) => {
       mode: debug ? 'development' : 'production',
       context: __dirname,
       resolve: {
+        extensions: ['.js', '.jsx'],
         alias: {
           'react-benchmark-test-component': benchmarkPath,
           // Prevent duplicate react's from being bundled
@@ -53,7 +54,7 @@ exports.compile = async (outputPath, benchmarkPath, debug) => {
         noParse: [/node_modules\/benchmark\//], // Parsing benchmark causes it to break
         rules: [
           {
-            test: /\.js$/,
+            test: /\.jsx?$/,
             exclude: path =>
               path.includes('node_modules') &&
               !path.includes('/react-benchmark/lib/'), // Don't exclude ourselves 😆


### PR DESCRIPTION
This PR supports `.jsx` files in module resolution and babel compilation so that we can benchmark components without additional compilation.