### PR TITLE
Enabled processing of TypeScript files and prevent AMD module creation

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -31,7 +31,7 @@ exports.compile = async (outputPath, benchmarkPath, debug) => {
       mode: debug ? 'development' : 'production',
       context: __dirname,
       resolve: {
-        extensions: ['.js', '.jsx'],
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         alias: {
           'react-benchmark-test-component': benchmarkPath,
           // Prevent duplicate react's from being bundled
@@ -54,7 +54,7 @@ exports.compile = async (outputPath, benchmarkPath, debug) => {
         noParse: [/node_modules\/benchmark\//], // Parsing benchmark causes it to break
         rules: [
           {
-            test: /\.jsx?$/,
+            test: /\.[jt]sx?$/,
             exclude: path =>
               path.includes('node_modules') &&
               !path.includes('/react-benchmark/lib/'), // Don't exclude ourselves 😆
@@ -66,7 +66,8 @@ exports.compile = async (outputPath, benchmarkPath, debug) => {
             }
           }
         ]
-      }
+      },
+      amd: false
     }
 
     if (debug) {


### PR DESCRIPTION
Currently, Webpack will not consume TypeScript (.ts/.tsx) files, instead warning that it has no way to process them. This allows Webpack to resolve TypeScript files to `babel-loader`.

Additionally, `benchmark.js` checks to see if AMD modules are available, and uses them if so. However, we do not actually produce AMD modules, so we forcibly disallow Webpack from doing so.