### PR TITLE
feat: enable CPU throttling with --cpuThrottle flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Options
   <path>          Path to a JavaScript or TypeScript file that exports the function to be benchmarked.
   --debug, -d     Run a development build instead of a production build to aid debugging.
   --devtools, -t  Run Chrome in windowed mode with the devtools open.
+  --cpuThrottle=X Run Chrome with CPU throttled X times.
   --version       Prints the version.
   --help          Prints this message.
 
@@ -76,7 +77,7 @@ Path to the benchmark file to run. See the [Usage](#usage) section for more deta
 #### options
 
 Type: `Object`
-Default: `{ debug: false, devtools: false }`
+Default: `{ debug: false, devtools: false, cpuThrottle: 1 }`
 
 Optional object containing additional options.
 
@@ -93,6 +94,13 @@ Type: `Boolean`<br>
 Default: `false`
 
 Run Chrome in windowed mode with the devtools open.
+
+##### cpuThrottle
+
+Type: `number`<br>
+Default: `1`
+
+Run Chrome with CPU throttled X times. Useful to receive more precise results between runs.
 
 ### Events
 

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -9,11 +9,14 @@ module.exports = class Chrome extends EventEmitter {
     this.chrome = null
   }
 
-  async start(port, devtools) {
+  async start(port, devtools, { cpuThrottle }) {
     let completed = false
 
     this.chrome = await puppeteer.launch({ devtools })
     const page = await this.chrome.newPage()
+    const client = await page.target().createCDPSession()
+
+    await client.send('Emulation.setCPUThrottlingRate', { rate: cpuThrottle })
 
     this.chrome.on('disconnected', () => {
       this.chrome = null

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,6 +15,7 @@ Options
   <path>          Path to a JavaScript or TypeScript file that exports the function to be benchmarked.
   --debug, -d     Run a development build instead of a production build to aid debugging.
   --devtools, -t  Run Chrome in windowed mode with the devtools open.
+  --cpuThrottle=X Run Chrome with CPU throttled X times.
   --version       Prints the version.
   --help          Prints this message.
 
@@ -32,6 +33,10 @@ Examples
       default: false,
       alias: 't',
     },
+    cpuThrottle: {
+      type: 'number',
+      default: 1,
+    },
   },
 })
 
@@ -44,7 +49,7 @@ async function main() {
   }
 
   const [filepath] = cli.input
-  const { debug, devtools } = cli.flags
+  const { debug, devtools, cpuThrottle } = cli.flags
 
   spinner = ora().start()
 
@@ -78,7 +83,11 @@ async function main() {
     spinner.render()
   })
 
-  const result = await reactBenchmark.run(filepath, { debug, devtools })
+  const result = await reactBenchmark.run(filepath, {
+    debug,
+    devtools,
+    cpuThrottle,
+  })
 
   spinner.stop()
   console.log(formatBenchmark(result))

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -17,6 +17,11 @@ export interface RunOptions {
    * @default false
    */
   devtools?: boolean
+  /**
+   * Run Chrome with CPU throttled X times. Useful to receive more precise results between runs.
+   * @default 1
+   */
+  cpuThrottle?: number
 }
 
 export default class ReactBenchmark extends EventEmitter {

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,10 @@ module.exports = class ReactBenchmark extends EventEmitter {
     this.running = false
   }
 
-  async run(filepath, { debug = false, devtools = false } = {}) {
+  async run(
+    filepath,
+    { debug = false, devtools = false, cpuThrottle = 1 } = {}
+  ) {
     if (this.running) {
       throw new Error('Benchmark is already running')
     }
@@ -76,7 +79,7 @@ module.exports = class ReactBenchmark extends EventEmitter {
 
       this.emit('chrome')
 
-      this.chrome.start(port, devtools)
+      this.chrome.start(port, devtools, { cpuThrottle })
     })
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,9 +28,9 @@ module.exports = class ReactBenchmark extends EventEmitter {
     })
   }
 
-  _shutdown() {
-    this.chrome.stop()
-    this.server.stop()
+  async _shutdown() {
+    await this.chrome.stop()
+    await this.server.stop()
     this.running = false
   }
 
@@ -61,19 +61,17 @@ module.exports = class ReactBenchmark extends EventEmitter {
     const port = await this.server.start(outputPath)
 
     return new Promise((resolve, reject) => {
-      this.chrome.once('complete', (benchmark) => {
+      this.chrome.once('complete', async (benchmark) => {
         if (!devtools) {
-          this._shutdown()
+          await this._shutdown()
         }
-
         resolve(benchmark)
       })
 
-      this.chrome.once('error', (err) => {
+      this.chrome.once('error', async (err) => {
         if (!devtools) {
-          this._shutdown()
+          await this._shutdown()
         }
-
         reject(err)
       })
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -2,6 +2,8 @@ const path = require('path')
 const test = require('ava')
 const execa = require('execa')
 
+const sleep = (ms) => new Promise((res) => setTimeout(res, ms))
+
 test('runs benchmark', async (t) => {
   const binPath = path.resolve(__dirname, '../lib/cli.js')
   const fixturePath = path.resolve(__dirname, 'fixtures/benchmark.js')
@@ -9,4 +11,24 @@ test('runs benchmark', async (t) => {
   const result = await execa(binPath, [fixturePath])
 
   t.regex(result.stdout, /[0-9,]+ ops\/sec ±[0-9.]+% \(\d+ runs sampled\)/)
+})
+
+test('throttles CPU', async (t) => {
+  const getOpsSec = (resultString) => {
+    return parseInt(
+      resultString.match(/([\d,]+) ops\/sec/)[1].replace(/,/g, '')
+    )
+  }
+  const binPath = path.resolve(__dirname, '../lib/cli.js')
+  const fixturePath = path.resolve(__dirname, 'fixtures/benchmark.js')
+
+  const woutT = (await execa(binPath, [fixturePath])).stdout
+  await sleep(100) // sometimes port is still in use
+  const withT = (await execa(binPath, [fixturePath, '--cpuThrottle=4'])).stdout
+
+  // difference should be more then 2 times
+  t.assert(
+    getOpsSec(woutT) - getOpsSec(withT) > getOpsSec(woutT) / 2,
+    'The difference between throttled and not throttled execution is less then normal'
+  )
 })

--- a/test/cli.js
+++ b/test/cli.js
@@ -2,8 +2,6 @@ const path = require('path')
 const test = require('ava')
 const execa = require('execa')
 
-const sleep = (ms) => new Promise((res) => setTimeout(res, ms))
-
 test('runs benchmark', async (t) => {
   const binPath = path.resolve(__dirname, '../lib/cli.js')
   const fixturePath = path.resolve(__dirname, 'fixtures/benchmark.js')
@@ -23,7 +21,6 @@ test('throttles CPU', async (t) => {
   const fixturePath = path.resolve(__dirname, 'fixtures/benchmark.js')
 
   const woutT = (await execa(binPath, [fixturePath])).stdout
-  await sleep(100) // sometimes port is still in use
   const withT = (await execa(binPath, [fixturePath, '--cpuThrottle=4'])).stdout
 
   // difference should be more then 2 times


### PR DESCRIPTION
### Feature description

To get more accurate results for comparison it is a good idea to run Chrome with 4x-8x CPU throttling. This way the results will be less influenced by other processes running on the same machine.

This PR adds a special `--cpuThrottle` which is 1 by default not to change the default behavior. User can set it to any number value (e.g. `--cpuThrottle 4`) to enable CPU throttling.

### PR description

- New CLI flag is added
- New options argument is added to `ReactBenchmark`
- New test is added to E2E tests (`test/cli.js`) to make sure this option works correctly
- Docs and typescript definitions are updated

P.S. I was using this project for my personal needs and I have much more changes to contribute in the future, such as:
- Testing performance not until component is rendered, but until `onReady` callback is called (useful for async tests)
- Measuring not only CPU, but also RAM consumption
- Measuring network consumption
- Adding configurable delay between tests to give Chrome some time to cooldown
- Optional rendering to DOM instead of in-memory rendering which is used right now